### PR TITLE
Don't close effector in BlocEffectListener

### DIFF
--- a/lib/src/bloc_effect_listener.dart
+++ b/lib/src/bloc_effect_listener.dart
@@ -102,7 +102,6 @@ class _BlocEffectListenerState<B extends Effects<E>, E>
   @override
   void dispose() {
     _unsubscribe();
-    _effector.close();
     super.dispose();
   }
 


### PR DESCRIPTION
Unless I'm missing something it feels like a bug that a the BloC or Cubit being listened to gets closed when the `BlocEffectListener` is disposed. Especially in our case where the Cubit in case is being provided much higher up in the widget tree.