### PR TITLE
Feature/bloc reference in observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+- Thanks to TheManuz for proposing source-aware effect observation and
+  contributing the initial implementations of `onBlocEffect` and
+  `BlocEffectConsumer`.
+- Added the source-aware `BlocWithEffectsObserver.onBlocEffect` callback while
+  preserving the existing `onEffect` callback.
+- Added `BlocEffectConsumer`.
+- Fixed context-provided effectors not updating when `BlocProvider` changes.
+- Fixed effects closing before in-flight Bloc handlers complete.
+
 ## 2.0.1
 - base_effector as a part of effector_mixin
 - quality of life(thanks to klaas-videc): added variables `context` and `effect` to [EffectWidgetListener] typedef 

--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ class CounterPage extends StatelessWidget {
             );
           }
         },
-        child: const Sizedbox(),
+        child: const SizedBox(),
       ),
       floatingActionButton: FloatingActionButton(
+        tooltip: 'Show effect',
         child: const Icon(Icons.upload),
         onPressed: () => context.read<CounterCubit>().onButtonPressed(),
       ),
@@ -122,12 +123,35 @@ callback to base observing features:
 ### app_bloc_observer.dart
 
  ```dart
- class AppBlocObserver extends BlocWithEffectsObserver {
+class AppBlocObserver extends BlocWithEffectsObserver {
+  const AppBlocObserver();
+
   @override
-  void onEffect(Object effect) {
-    super.onEffect(effect);
-    debugPrint('Used effect: $effect');
+  void onBlocEffect(BlocBase<dynamic> bloc, Object? effect) {
+    super.onBlocEffect(bloc, effect);
+    debugPrint('${bloc.runtimeType} emitted $effect');
   }
-// Other [BlocObserver] overrides
+
+  // Other BlocObserver overrides.
 }
- ```
+```
+
+Install the observer before creating any blocs or cubits:
+
+```dart
+void main() {
+  Bloc.observer = const AppBlocObserver();
+  runApp(const CounterApp());
+}
+```
+
+`BlocEffectConsumer` combines `BlocBuilder` and `BlocEffectListener` when the
+same bloc is used for both state-driven UI and transient effects.
+`CubitWithEffects` and `BlocWithEffects` implement its combined contract. A
+class using the `Effects` mixin directly can opt in by also implementing
+`BlocEffectsSource<State, Effect>`.
+
+Effects are transient, non-buffered broadcast events. Every active listener
+receives each emission once. Emissions without active listeners are discarded,
+and new listeners do not receive past effects. Use one route-scoped listener
+for exclusive UI actions such as navigation and dialogs.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,7 +12,7 @@ class ShowBottomSheet implements DemoEffect {
   const ShowBottomSheet();
 }
 
-class DemoCubit extends Cubit<void> with Effects<void, DemoEffect> {
+class DemoCubit extends Cubit<void> with Effects<DemoEffect> {
   DemoCubit() : super(null);
 
   void onButtonPressed() => emitEffect(const ShowBottomSheet());
@@ -44,7 +44,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        body: BlocEffectListener<DemoCubit, void, DemoEffect>(
+        body: BlocEffectListener<DemoCubit, DemoEffect>(
           effector: _demoCubit,
           listener: (context, effect) {
             if (effect is ShowBottomSheet) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,7 +12,7 @@ class ShowBottomSheet implements DemoEffect {
   const ShowBottomSheet();
 }
 
-class DemoCubit extends Cubit<void> with Effects<DemoEffect> {
+class DemoCubit extends Cubit<void> with Effects<void, DemoEffect> {
   DemoCubit() : super(null);
 
   void onButtonPressed() => emitEffect(const ShowBottomSheet());
@@ -44,7 +44,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        body: BlocEffectListener<DemoCubit, DemoEffect>(
+        body: BlocEffectListener<DemoCubit, void, DemoEffect>(
           effector: _demoCubit,
           listener: (context, effect) {
             if (effect is ShowBottomSheet) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -15,23 +15,23 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -81,10 +81,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   nested:
     dependency: transitive
     description:
@@ -110,10 +110,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=1.16.0"

--- a/lib/bloc_effects.dart
+++ b/lib/bloc_effects.dart
@@ -1,5 +1,6 @@
-export '/src/bloc_effect_listener.dart';
-export '/src/bloc_with_effects.dart';
-export '/src/bloc_with_effects_observer.dart';
-export '/src/cubit_with_effects.dart';
-export '/src/effects_mixin.dart';
+export 'src/bloc_effect_consumer.dart';
+export 'src/bloc_effect_listener.dart';
+export 'src/bloc_with_effects.dart';
+export 'src/bloc_with_effects_observer.dart';
+export 'src/cubit_with_effects.dart';
+export 'src/effects_mixin.dart';

--- a/lib/src/base_effector.dart
+++ b/lib/src/base_effector.dart
@@ -18,6 +18,13 @@ abstract class EffectsStreamable<T extends Object?> {
   Stream<T> get effectsStream;
 }
 
+/// A source that exposes both a current [state] and transient [effectsStream].
+///
+/// This combined contract is intended for widgets which consume both state and
+/// effects, such as `BlocEffectConsumer`.
+abstract class BlocEffectsSource<State, Effect>
+    implements StateStreamable<State>, EffectsStreamable<Effect> {}
+
 /// An object that can emit new effects.
 abstract class EffectsUsable<Effect extends Object?> {
   /// Emits a new [effect].

--- a/lib/src/bloc_effect_consumer.dart
+++ b/lib/src/bloc_effect_consumer.dart
@@ -1,0 +1,102 @@
+import 'package:bloc_effects/src/bloc_effect_listener.dart';
+import 'package:bloc_effects/src/effects_mixin.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// {@template bloc_effect_consumer}
+/// [BlocEffectConsumer] exposes a [builder] and [listener] in order react to
+/// new states.
+/// [BlocEffectConsumer] is analogous to a nested `BlocEffectListener`
+/// and `BlocBuilder` but reduces the amount of boilerplate needed.
+/// [BlocEffectConsumer] should only be used when it is necessary to both
+/// rebuild UI and execute other reactions to effects in the [bloc].
+///
+/// [BlocEffectConsumer] takes a required `BlocWidgetBuilder`
+/// and `BlocEffectListener` and an optional [bloc],
+/// `BlocBuilderCondition`.
+///
+/// If the [bloc] parameter is omitted, [BlocEffectConsumer] will automatically
+/// perform a lookup using `BlocProvider` and the current `BuildContext`.
+///
+/// ```dart
+/// BlocEffectConsumer<BlocA, BlocAState, BlocAEffect>(
+///   listener: (context, effect) {
+///     // do stuff here based on BlocA's effect
+///   },
+///   builder: (context, state) {
+///     // return widget here based on BlocA's state
+///   }
+/// )
+/// ```
+///
+/// An optional [buildWhen] can be implemented for more granular control over
+/// how often [BlocEffectConsumer] rebuilds.
+/// [buildWhen] should only be used for performance optimizations as it
+/// provides no security about the state passed to the [builder] function.
+/// [buildWhen] will be invoked on each [bloc] `state` change.
+/// [buildWhen] takes the previous `state` and current `state` and must
+/// return a [bool] which determines whether or not the [builder] function will
+/// be invoked.
+/// The previous `state` will be initialized to the `state` of the [bloc] when
+/// the [BlocEffectConsumer] is initialized.
+/// [buildWhen] is optional and if omitted, it will default to `true`.
+///
+/// ```dart
+/// BlocEffectConsumer<BlocA, BlocAState, BlocAEffect>(
+///   listener: (context, effect) {
+///     // do stuff here based on BlocA's effect
+///   },
+///   buildWhen: (previous, current) {
+///     // return true/false to determine whether or not
+///     // to rebuild the widget with state
+///   },
+///   builder: (context, state) {
+///     // return widget here based on BlocA's state
+///   }
+/// )
+/// ```
+/// {@endtemplate}
+class BlocEffectConsumer<B extends Effects<S, E>, S, E>
+    extends StatelessWidget {
+  /// {@macro bloc_effect_consumer}
+  const BlocEffectConsumer({
+    required this.builder,
+    required this.listener,
+    super.key,
+    this.bloc,
+    this.buildWhen,
+  });
+
+  /// The [bloc] that the [BlocConsumer] will interact with.
+  /// If omitted, [BlocConsumer] will automatically perform a lookup using
+  /// `BlocProvider` and the current `BuildContext`.
+  final B? bloc;
+
+  /// The [builder] function which will be invoked on each widget build.
+  /// The [builder] takes the `BuildContext` and current `state` and
+  /// must return a widget.
+  /// This is analogous to the [builder] function in [StreamBuilder].
+  final BlocWidgetBuilder<S> builder;
+
+  /// Takes the `BuildContext` along with the [bloc] `effect`
+  /// and is responsible for executing in response to `effect` changes.
+  final EffectWidgetListener<E> listener;
+
+  /// Takes the previous `state` and the current `state` and is responsible for
+  /// returning a [bool] which determines whether or not to trigger
+  /// [builder] with the current `state`.
+  final BlocBuilderCondition<S>? buildWhen;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocEffectListener<B, S, E>(
+      listener: listener,
+      effector: bloc,
+      child: BlocBuilder<B, S>(
+        bloc: bloc,
+        builder: builder,
+        buildWhen: buildWhen,
+      ),
+    );
+  }
+}

--- a/lib/src/bloc_effect_consumer.dart
+++ b/lib/src/bloc_effect_consumer.dart
@@ -32,7 +32,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// An optional [buildWhen] can be implemented for more granular control over
 /// how often [BlocEffectConsumer] rebuilds.
 /// [buildWhen] should only be used for performance optimizations as it
-/// provides no security about the state passed to the [builder] function.
+/// provides no guarantee about the state passed to the [builder] function.
 /// [buildWhen] will be invoked on each [bloc] `state` change.
 /// [buildWhen] takes the previous `state` and current `state` and must
 /// return a [bool] which determines whether or not the [builder] function will
@@ -56,7 +56,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// )
 /// ```
 /// {@endtemplate}
-class BlocEffectConsumer<B extends Effects<S, E>, S, E>
+class BlocEffectConsumer<B extends BlocEffectsSource<S, E>, S, E>
     extends StatelessWidget {
   /// {@macro bloc_effect_consumer}
   const BlocEffectConsumer({
@@ -89,7 +89,7 @@ class BlocEffectConsumer<B extends Effects<S, E>, S, E>
 
   @override
   Widget build(BuildContext context) {
-    return BlocEffectListener<B, S, E>(
+    return BlocEffectListener<B, E>(
       listener: listener,
       effector: bloc,
       child: BlocBuilder<B, S>(

--- a/lib/src/bloc_effect_listener.dart
+++ b/lib/src/bloc_effect_listener.dart
@@ -49,7 +49,7 @@ typedef EffectWidgetListener<Effect> = void Function(
 /// )
 /// ```
 /// {@endtemplate}
-class BlocEffectListener<B extends Effects<E>, E> extends StatefulWidget {
+class BlocEffectListener<B extends Effects<S, E>, S, E> extends StatefulWidget {
   /// {@macro bloc_effect_listener}
   const BlocEffectListener({
     required this.listener,
@@ -72,12 +72,12 @@ class BlocEffectListener<B extends Effects<E>, E> extends StatefulWidget {
   final Widget child;
 
   @override
-  State<BlocEffectListener<B, E>> createState() =>
-      _BlocEffectListenerState<B, E>();
+  State<BlocEffectListener<B, S, E>> createState() =>
+      _BlocEffectListenerState<B, S, E>();
 }
 
-class _BlocEffectListenerState<B extends Effects<E>, E>
-    extends State<BlocEffectListener<B, E>> {
+class _BlocEffectListenerState<B extends Effects<S, E>, S, E>
+    extends State<BlocEffectListener<B, S, E>> {
   StreamSubscription<E>? _subscription;
   late B _effector;
 
@@ -112,7 +112,7 @@ class _BlocEffectListenerState<B extends Effects<E>, E>
   }
 
   @override
-  void didUpdateWidget(BlocEffectListener<B, E> oldWidget) {
+  void didUpdateWidget(BlocEffectListener<B, S, E> oldWidget) {
     super.didUpdateWidget(oldWidget);
     final oldEffector = oldWidget.effector ?? context.read<B>();
     final currentEffector = widget.effector ?? oldEffector;

--- a/lib/src/bloc_effect_listener.dart
+++ b/lib/src/bloc_effect_listener.dart
@@ -49,7 +49,8 @@ typedef EffectWidgetListener<Effect> = void Function(
 /// )
 /// ```
 /// {@endtemplate}
-class BlocEffectListener<B extends Effects<S, E>, S, E> extends StatefulWidget {
+class BlocEffectListener<B extends EffectsStreamable<E>, E>
+    extends StatefulWidget {
   /// {@macro bloc_effect_listener}
   const BlocEffectListener({
     required this.listener,
@@ -72,25 +73,27 @@ class BlocEffectListener<B extends Effects<S, E>, S, E> extends StatefulWidget {
   final Widget child;
 
   @override
-  State<BlocEffectListener<B, S, E>> createState() =>
-      _BlocEffectListenerState<B, S, E>();
+  State<BlocEffectListener<B, E>> createState() =>
+      _BlocEffectListenerState<B, E>();
 }
 
-class _BlocEffectListenerState<B extends Effects<S, E>, S, E>
-    extends State<BlocEffectListener<B, S, E>> {
+class _BlocEffectListenerState<B extends EffectsStreamable<E>, E>
+    extends State<BlocEffectListener<B, E>> {
   StreamSubscription<E>? _subscription;
   late B _effector;
 
   void _subscribe() {
-    final context = this.context;
+    _subscription = _effector.effectsStream.listen((effect) {
+      if (!mounted) return;
+      widget.listener(context, effect);
+    });
+  }
 
-    _subscription = _effector.effectsStream.listen(
-      (effect) {
-        if (context.mounted) {
-          widget.listener(context, effect);
-        }
-      },
-    );
+  void _replaceEffector(B nextEffector) {
+    if (identical(_effector, nextEffector)) return;
+    _unsubscribe();
+    _effector = nextEffector;
+    _subscribe();
   }
 
   void _unsubscribe() {
@@ -112,19 +115,24 @@ class _BlocEffectListenerState<B extends Effects<S, E>, S, E>
   }
 
   @override
-  void didUpdateWidget(BlocEffectListener<B, S, E> oldWidget) {
+  void didUpdateWidget(BlocEffectListener<B, E> oldWidget) {
     super.didUpdateWidget(oldWidget);
-    final oldEffector = oldWidget.effector ?? context.read<B>();
-    final currentEffector = widget.effector ?? oldEffector;
-    if (oldEffector != currentEffector) {
-      if (_subscription != null) {
-        _unsubscribe();
-        _effector = currentEffector;
-      }
-      _subscribe();
-    }
+    _replaceEffector(widget.effector ?? context.read<B>());
   }
 
   @override
-  Widget build(BuildContext context) => widget.child;
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _replaceEffector(widget.effector ?? context.read<B>());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.effector == null) {
+      context.select<B, bool>(
+        (candidate) => identical(candidate, _effector),
+      );
+    }
+    return widget.child;
+  }
 }

--- a/lib/src/bloc_with_effects.dart
+++ b/lib/src/bloc_with_effects.dart
@@ -6,7 +6,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// and add the [emitEffect] method to [Bloc] features.
 /// {@endtemplate}
 abstract class BlocWithEffects<Event, State, Effect> extends Bloc<Event, State>
-    with Effects<State, Effect> {
+    with Effects<Effect>
+    implements BlocEffectsSource<State, Effect> {
   /// {@macro bloc}
   BlocWithEffects(super.initialState);
 }

--- a/lib/src/bloc_with_effects.dart
+++ b/lib/src/bloc_with_effects.dart
@@ -6,7 +6,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// and add the [emitEffect] method to [Bloc] features.
 /// {@endtemplate}
 abstract class BlocWithEffects<Event, State, Effect> extends Bloc<Event, State>
-    with Effects<Effect> {
+    with Effects<State, Effect> {
   /// {@macro bloc}
   BlocWithEffects(super.initialState);
 }

--- a/lib/src/bloc_with_effects_observer.dart
+++ b/lib/src/bloc_with_effects_observer.dart
@@ -5,8 +5,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// of [Bloc] instances.
 abstract class BlocWithEffectsObserver extends BlocObserver {
   /// Called whenever an [effect] is `used` from any [BlocBase] implementation
-  ///  with the given [effect].
+  /// with the given [effect].
   @protected
   @mustCallSuper
-  void onEffect<E>(E effect) {}
+  void onEffect<E>(BlocBase<dynamic> bloc, E effect) {}
 }

--- a/lib/src/bloc_with_effects_observer.dart
+++ b/lib/src/bloc_with_effects_observer.dart
@@ -4,9 +4,23 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 /// An interface, witch add observing the effects using behavior
 /// of [Bloc] instances.
 abstract class BlocWithEffectsObserver extends BlocObserver {
-  /// Called whenever an [effect] is `used` from any [BlocBase] implementation
-  /// with the given [effect].
+  /// Creates an observer for blocs and their effects.
+  const BlocWithEffectsObserver();
+
+  /// Called whenever an [effect] is emitted from an effects implementation.
+  ///
+  /// Override [onBlocEffect] when the emitting bloc is required.
   @protected
   @mustCallSuper
-  void onEffect<E>(BlocBase<dynamic> bloc, E effect) {}
+  void onEffect<E>(E effect) {}
+
+  /// Called whenever [bloc] emits an [effect].
+  ///
+  /// The default implementation delegates to [onEffect] so observers written
+  /// for bloc_effects 2.x continue to receive effects.
+  @protected
+  @mustCallSuper
+  void onBlocEffect(BlocBase<dynamic> bloc, Object? effect) {
+    onEffect<Object?>(effect);
+  }
 }

--- a/lib/src/cubit_with_effects.dart
+++ b/lib/src/cubit_with_effects.dart
@@ -19,7 +19,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 ///
 /// {@endtemplate}
 abstract class CubitWithEffects<State, Effect> extends Cubit<State>
-    with Effects<Effect> {
+    with Effects<State, Effect> {
   /// {@macro cubit}
   CubitWithEffects(super.initialState);
 }

--- a/lib/src/cubit_with_effects.dart
+++ b/lib/src/cubit_with_effects.dart
@@ -19,7 +19,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 ///
 /// {@endtemplate}
 abstract class CubitWithEffects<State, Effect> extends Cubit<State>
-    with Effects<State, Effect> {
+    with Effects<Effect>
+    implements BlocEffectsSource<State, Effect> {
   /// {@macro cubit}
   CubitWithEffects(super.initialState);
 }

--- a/lib/src/effects_mixin.dart
+++ b/lib/src/effects_mixin.dart
@@ -1,19 +1,24 @@
 import 'dart:async';
 
-import 'package:bloc_effects/bloc_effects.dart';
+import 'package:bloc_effects/src/bloc_with_effects_observer.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 part 'base_effector.dart';
 
 /// Mixin [Effects] provides implementation for [BaseEffector]
-mixin Effects<State, E> on BlocBase<State> implements BaseEffector<E> {
+mixin Effects<E> on Closable implements BaseEffector<E> {
   late final _effectController = StreamController<E>.broadcast();
+  Future<void>? _effectsCloseFuture;
+  Future<void>? _closeFuture;
 
-  BlocWithEffectsObserver? get _effectsBlocObserver {
+  static BlocWithEffectsObserver? _resolveEffectsBlocObserver() {
     final observer = Bloc.observer;
     return observer is BlocWithEffectsObserver ? observer : null;
   }
+
+  final BlocWithEffectsObserver? _effectsBlocObserver =
+      _resolveEffectsBlocObserver();
 
   @override
   Stream<E> get effectsStream => _effectController.stream;
@@ -21,34 +26,50 @@ mixin Effects<State, E> on BlocBase<State> implements BaseEffector<E> {
   @override
   bool get isEffectsClosed => _effectController.isClosed;
 
+  void _notifyEffectObserver(E effect) {
+    final observer = _effectsBlocObserver;
+    if (observer == null) return;
+
+    final Object source = this;
+    if (source is BlocBase<dynamic>) {
+      // ignore: invalid_use_of_protected_member
+      observer.onBlocEffect(source, effect);
+    } else {
+      // ignore: invalid_use_of_protected_member
+      observer.onEffect<E>(effect);
+    }
+  }
+
   @protected
   @visibleForTesting
   @override
   void emitEffect(E effect) {
-    if (!isEffectsClosed) {}
-
     if (isClosed || isEffectsClosed) {
       throw StateError('Cannot use effects after calling close');
     }
 
-    // ignore: invalid_use_of_protected_member
-    _effectsBlocObserver?.onEffect(this, effect);
     _effectController.add(effect);
+    _notifyEffectObserver(effect);
   }
 
   @protected
   @mustCallSuper
   @override
-  Future<void> closeEffects() async {
-    await _effectController.close();
+  Future<void> closeEffects() {
+    return _effectsCloseFuture ??= _effectController.close();
   }
 
   @mustCallSuper
   @override
-  Future<void> close() async {
-    if (!isEffectsClosed) {
+  Future<void> close() {
+    return _closeFuture ??= _close();
+  }
+
+  Future<void> _close() async {
+    try {
+      await super.close();
+    } finally {
       await closeEffects();
     }
-    await super.close();
   }
 }

--- a/lib/src/effects_mixin.dart
+++ b/lib/src/effects_mixin.dart
@@ -7,7 +7,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 part 'base_effector.dart';
 
 /// Mixin [Effects] provides implementation for [BaseEffector]
-mixin Effects<E> on Closable implements BaseEffector<E> {
+mixin Effects<State, E> on BlocBase<State> implements BaseEffector<E> {
   late final _effectController = StreamController<E>.broadcast();
 
   BlocWithEffectsObserver? get _effectsBlocObserver {
@@ -32,7 +32,7 @@ mixin Effects<E> on Closable implements BaseEffector<E> {
     }
 
     // ignore: invalid_use_of_protected_member
-    _effectsBlocObserver?.onEffect(effect);
+    _effectsBlocObserver?.onEffect(this, effect);
     _effectController.add(effect);
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,34 +29,34 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -79,34 +79,34 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -119,10 +119,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   nested:
     dependency: transitive
     description:
@@ -135,10 +135,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   provider:
     dependency: transitive
     description:
@@ -164,18 +164,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -196,18 +196,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -217,5 +217,5 @@ packages:
     source: hosted
     version: "14.3.0"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/test/bloc_effect_consumer_test.dart
+++ b/test/bloc_effect_consumer_test.dart
@@ -1,5 +1,4 @@
 import 'package:bloc_effects/bloc_effects.dart';
-import 'package:bloc_effects/src/bloc_effect_consumer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -33,8 +32,35 @@ class TestBloc extends BlocWithEffects<TestEvent, int, TestEffect> {
   void _onIncrement(_, Emitter<int> emit) => emit(state + 1);
 }
 
+class ProviderConsumerHarness extends StatelessWidget {
+  const ProviderConsumerHarness({
+    required this.cubit,
+    required this.effectStates,
+    super.key,
+  });
+
+  final TestCubit cubit;
+  final List<int> effectStates;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<TestCubit>.value(
+      value: cubit,
+      child: BlocEffectConsumer<TestCubit, int, TestEffect>(
+        listener: (_, effect) {
+          if (effect is ShowSnackBar) effectStates.add(effect.stateValue);
+        },
+        builder: (_, state) => Directionality(
+          textDirection: TextDirection.ltr,
+          child: Text('$state'),
+        ),
+      ),
+    );
+  }
+}
+
 void main() {
-  group('BlocEffectListener', () {
+  group('BlocEffectConsumer', () {
     testWidgets('renders child properly', (tester) async {
       const targetKey = Key('cubit_listener_container');
       final testCubit = TestCubit();
@@ -131,6 +157,36 @@ void main() {
       await tester.pumpAndSettle();
       expect(effects.map((e) => e.runtimeType), expectedEffects);
       expect(find.text('2'), findsOneWidget);
+    });
+
+    testWidgets('keeps builder and listener on the same replacement cubit',
+        (tester) async {
+      final firstCubit = TestCubit(value: 1);
+      final secondCubit = TestCubit(value: 100);
+      final effectStates = <int>[];
+      addTearDown(firstCubit.close);
+      addTearDown(secondCubit.close);
+
+      await tester.pumpWidget(
+        ProviderConsumerHarness(
+          cubit: firstCubit,
+          effectStates: effectStates,
+        ),
+      );
+      await tester.pumpWidget(
+        ProviderConsumerHarness(
+          cubit: secondCubit,
+          effectStates: effectStates,
+        ),
+      );
+      expect(find.text('100'), findsOneWidget);
+
+      secondCubit.showSnackBar();
+      await tester.pump();
+      firstCubit.showSnackBar();
+      await tester.pump();
+
+      expect(effectStates, <int>[100]);
     });
   });
 }

--- a/test/bloc_effect_consumer_test.dart
+++ b/test/bloc_effect_consumer_test.dart
@@ -1,0 +1,136 @@
+import 'package:bloc_effects/bloc_effects.dart';
+import 'package:bloc_effects/src/bloc_effect_consumer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'bloc_effect_listener_test.dart';
+
+abstract class TestEvent {}
+
+class ButtonPressed implements TestEvent {
+  const ButtonPressed();
+}
+
+class Increment implements TestEvent {
+  const Increment();
+}
+
+class TestCubit extends CubitWithEffects<int, TestEffect> {
+  TestCubit({int value = 0}) : super(value);
+
+  void showSnackBar() => emitEffect(ShowSnackBar(state));
+  void increment() => emit(state + 1);
+}
+
+class TestBloc extends BlocWithEffects<TestEvent, int, TestEffect> {
+  TestBloc({int value = 0}) : super(value) {
+    on<ButtonPressed>(_onButtonPressed);
+    on<Increment>(_onIncrement);
+  }
+
+  void _onButtonPressed(_, __) => emitEffect(ShowSnackBar(state));
+  void _onIncrement(_, Emitter<int> emit) => emit(state + 1);
+}
+
+void main() {
+  group('BlocEffectListener', () {
+    testWidgets('renders child properly', (tester) async {
+      const targetKey = Key('cubit_listener_container');
+      final testCubit = TestCubit();
+      await tester.pumpWidget(
+        BlocEffectConsumer<TestCubit, int, TestEffect>(
+          bloc: testCubit,
+          listener: (_, __) {},
+          builder: (_, int value) => Directionality(
+            textDirection: TextDirection.ltr,
+            child: Text(
+              '$value',
+              key: targetKey,
+            ),
+          ),
+        ),
+      );
+      expect(find.byKey(targetKey), findsOneWidget);
+      expect(find.text('0'), findsOneWidget);
+    });
+
+    testWidgets('calls listener on single effect used from TestCubit',
+        (tester) async {
+      final testCubit = TestCubit();
+      final effects = <TestEffect>[];
+      const expectedEffects = [ShowSnackBar];
+      await tester.pumpWidget(
+        BlocEffectConsumer<TestCubit, int, TestEffect>(
+          bloc: testCubit,
+          listener: (_, effect) => effects.add(effect),
+          builder: (_, int value) => Directionality(
+            textDirection: TextDirection.ltr,
+            child: Text(
+              '$value',
+            ),
+          ),
+        ),
+      );
+      testCubit
+        ..showSnackBar()
+        ..increment();
+      await tester.pumpAndSettle();
+      expect(effects.map((e) => e.runtimeType), expectedEffects);
+      expect(find.text('1'), findsOneWidget);
+    });
+
+    testWidgets('calls listener on single effect used from TestBloc',
+        (tester) async {
+      final testBloc = TestBloc();
+      final effects = <TestEffect>[];
+      const expectedEffects = [ShowSnackBar];
+      await tester.pumpWidget(
+        BlocEffectConsumer<TestBloc, int, TestEffect>(
+          bloc: testBloc,
+          listener: (_, effect) => effects.add(effect),
+          builder: (_, int value) => Directionality(
+            textDirection: TextDirection.ltr,
+            child: Text(
+              '$value',
+            ),
+          ),
+        ),
+      );
+      testBloc
+        ..add(const ButtonPressed())
+        ..add(const Increment());
+      await tester.pumpAndSettle();
+      expect(effects.map((e) => e.runtimeType), expectedEffects);
+      expect(find.text('1'), findsOneWidget);
+    });
+
+    testWidgets('calls listener on multiple effects used', (tester) async {
+      final testCubit = TestCubit();
+      final effects = <TestEffect>[];
+      const expectedEffects = [ShowSnackBar, ShowSnackBar];
+      await tester.pumpWidget(
+        BlocEffectConsumer<TestCubit, int, TestEffect>(
+          bloc: testCubit,
+          listener: (_, effect) => effects.add(effect),
+          builder: (_, int value) => Directionality(
+            textDirection: TextDirection.ltr,
+            child: Text(
+              '$value',
+            ),
+          ),
+        ),
+      );
+      testCubit
+        ..showSnackBar()
+        ..increment();
+      await tester.pumpAndSettle();
+      testCubit
+        ..showSnackBar()
+        ..increment();
+      await tester.pumpAndSettle();
+      expect(effects.map((e) => e.runtimeType), expectedEffects);
+      expect(find.text('2'), findsOneWidget);
+    });
+  });
+}

--- a/test/bloc_effect_listener_test.dart
+++ b/test/bloc_effect_listener_test.dart
@@ -67,7 +67,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        body: BlocEffectListener<TestCubit, int, TestEffect>(
+        body: BlocEffectListener<TestCubit, TestEffect>(
           effector: _testCubit,
           listener: (context, effect) {
             widget.onListenerCalled?.call(context, effect);
@@ -101,13 +101,37 @@ class _MyAppState extends State<MyApp> {
   }
 }
 
+class ProviderListenerHarness extends StatelessWidget {
+  const ProviderListenerHarness({
+    required this.cubit,
+    required this.states,
+    super.key,
+  });
+
+  final TestCubit cubit;
+  final List<int> states;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider<TestCubit>.value(
+      value: cubit,
+      child: BlocEffectListener<TestCubit, TestEffect>(
+        listener: (_, effect) {
+          if (effect is ShowSnackBar) states.add(effect.stateValue);
+        },
+        child: const SizedBox(),
+      ),
+    );
+  }
+}
+
 void main() {
   group('BlocEffectListener', () {
     testWidgets('renders child properly', (tester) async {
       const targetKey = Key('cubit_listener_container');
       final testCubit = TestCubit();
       await tester.pumpWidget(
-        BlocEffectListener<TestCubit, int, TestEffect>(
+        BlocEffectListener<TestCubit, TestEffect>(
           effector: testCubit,
           listener: (_, __) {},
           child: const SizedBox(key: targetKey),
@@ -122,7 +146,7 @@ void main() {
       final effects = <TestEffect>[];
       const expectedEffects = [ShowSnackBar];
       await tester.pumpWidget(
-        BlocEffectListener<TestCubit, int, TestEffect>(
+        BlocEffectListener<TestCubit, TestEffect>(
           effector: testCubit,
           listener: (_, effect) {
             effects.add(effect);
@@ -141,7 +165,7 @@ void main() {
       final effects = <TestEffect>[];
       const expectedEffects = [ShowSnackBar];
       await tester.pumpWidget(
-        BlocEffectListener<TestBloc, int, TestEffect>(
+        BlocEffectListener<TestBloc, TestEffect>(
           effector: testBloc,
           listener: (_, effect) {
             effects.add(effect);
@@ -159,7 +183,7 @@ void main() {
       final effects = <TestEffect>[];
       const expectedEffects = [ShowSnackBar, ShowSnackBar];
       await tester.pumpWidget(
-        BlocEffectListener<TestCubit, int, TestEffect>(
+        BlocEffectListener<TestCubit, TestEffect>(
           effector: testCubit,
           listener: (_, effect) {
             effects.add(effect);
@@ -255,7 +279,7 @@ void main() {
       final effects = <TestEffect>[];
       final testCubit = TestCubit();
       await tester.pumpWidget(
-        BlocEffectListener<TestCubit, int, TestEffect>(
+        BlocEffectListener<TestCubit, TestEffect>(
           effector: testCubit,
           listener: (_, effect) {
             effects.add(effect);
@@ -306,7 +330,7 @@ void main() {
       await tester.pumpWidget(
         BlocProvider.value(
           value: testCubit,
-          child: BlocEffectListener<TestCubit, int, TestEffect>(
+          child: BlocEffectListener<TestCubit, TestEffect>(
             listener: (context, effect) {
               listenCallCount++;
               latestEffect = effect;
@@ -336,7 +360,7 @@ void main() {
       await tester.pumpWidget(
         BlocProvider.value(
           value: firstTestCubit,
-          child: BlocEffectListener<TestCubit, int, TestEffect>(
+          child: BlocEffectListener<TestCubit, TestEffect>(
             effector: firstTestCubit,
             listener: (_, effect) {
               if (effect is ShowSnackBar) {
@@ -353,7 +377,7 @@ void main() {
       await tester.pumpWidget(
         BlocProvider.value(
           value: secondTestCubit,
-          child: BlocEffectListener<TestCubit, int, TestEffect>(
+          child: BlocEffectListener<TestCubit, TestEffect>(
             effector: secondTestCubit,
             listener: (_, effect) {
               if (effect is ShowSnackBar) {
@@ -371,6 +395,30 @@ void main() {
       await tester.pump();
 
       expect(states, expectedStates);
+    });
+
+    testWidgets('follows a replacement context-provided cubit', (tester) async {
+      final firstCubit = TestCubit(value: 1);
+      final secondCubit = TestCubit(value: 100);
+      final states = <int>[];
+      addTearDown(firstCubit.close);
+      addTearDown(secondCubit.close);
+
+      await tester.pumpWidget(
+        ProviderListenerHarness(cubit: firstCubit, states: states),
+      );
+      firstCubit.showSnackBar();
+      await tester.pump();
+
+      await tester.pumpWidget(
+        ProviderListenerHarness(cubit: secondCubit, states: states),
+      );
+      secondCubit.showSnackBar();
+      await tester.pump();
+      firstCubit.showSnackBar();
+      await tester.pump();
+
+      expect(states, <int>[1, 100]);
     });
   });
 }

--- a/test/bloc_effect_listener_test.dart
+++ b/test/bloc_effect_listener_test.dart
@@ -67,7 +67,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        body: BlocEffectListener<TestCubit, TestEffect>(
+        body: BlocEffectListener<TestCubit, int, TestEffect>(
           effector: _testCubit,
           listener: (context, effect) {
             widget.onListenerCalled?.call(context, effect);
@@ -107,7 +107,7 @@ void main() {
       const targetKey = Key('cubit_listener_container');
       final testCubit = TestCubit();
       await tester.pumpWidget(
-        BlocEffectListener<TestCubit, TestEffect>(
+        BlocEffectListener<TestCubit, int, TestEffect>(
           effector: testCubit,
           listener: (_, __) {},
           child: const SizedBox(key: targetKey),
@@ -122,7 +122,7 @@ void main() {
       final effects = <TestEffect>[];
       const expectedEffects = [ShowSnackBar];
       await tester.pumpWidget(
-        BlocEffectListener<TestCubit, TestEffect>(
+        BlocEffectListener<TestCubit, int, TestEffect>(
           effector: testCubit,
           listener: (_, effect) {
             effects.add(effect);
@@ -141,7 +141,7 @@ void main() {
       final effects = <TestEffect>[];
       const expectedEffects = [ShowSnackBar];
       await tester.pumpWidget(
-        BlocEffectListener<TestBloc, TestEffect>(
+        BlocEffectListener<TestBloc, int, TestEffect>(
           effector: testBloc,
           listener: (_, effect) {
             effects.add(effect);
@@ -159,7 +159,7 @@ void main() {
       final effects = <TestEffect>[];
       const expectedEffects = [ShowSnackBar, ShowSnackBar];
       await tester.pumpWidget(
-        BlocEffectListener<TestCubit, TestEffect>(
+        BlocEffectListener<TestCubit, int, TestEffect>(
           effector: testCubit,
           listener: (_, effect) {
             effects.add(effect);
@@ -255,7 +255,7 @@ void main() {
       final effects = <TestEffect>[];
       final testCubit = TestCubit();
       await tester.pumpWidget(
-        BlocEffectListener<TestCubit, TestEffect>(
+        BlocEffectListener<TestCubit, int, TestEffect>(
           effector: testCubit,
           listener: (_, effect) {
             effects.add(effect);
@@ -306,7 +306,7 @@ void main() {
       await tester.pumpWidget(
         BlocProvider.value(
           value: testCubit,
-          child: BlocEffectListener<TestCubit, TestEffect>(
+          child: BlocEffectListener<TestCubit, int, TestEffect>(
             listener: (context, effect) {
               listenCallCount++;
               latestEffect = effect;
@@ -336,7 +336,7 @@ void main() {
       await tester.pumpWidget(
         BlocProvider.value(
           value: firstTestCubit,
-          child: BlocEffectListener<TestCubit, TestEffect>(
+          child: BlocEffectListener<TestCubit, int, TestEffect>(
             effector: firstTestCubit,
             listener: (_, effect) {
               if (effect is ShowSnackBar) {
@@ -353,7 +353,7 @@ void main() {
       await tester.pumpWidget(
         BlocProvider.value(
           value: secondTestCubit,
-          child: BlocEffectListener<TestCubit, TestEffect>(
+          child: BlocEffectListener<TestCubit, int, TestEffect>(
             effector: secondTestCubit,
             listener: (_, effect) {
               if (effect is ShowSnackBar) {

--- a/test/bloc_effector_test.dart
+++ b/test/bloc_effector_test.dart
@@ -1,8 +1,26 @@
 import 'dart:async';
 
+import 'package:bloc_effects/bloc_effects.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'bloc_effect_listener_test.dart';
+
+class DelayedEvent {
+  const DelayedEvent();
+}
+
+class DelayedBloc extends BlocWithEffects<DelayedEvent, int, TestEffect> {
+  DelayedBloc({required this.started, required this.release}) : super(0) {
+    on<DelayedEvent>((event, emit) async {
+      started.complete();
+      await release.future;
+      emitEffect(const ShowSnackBar(1));
+    });
+  }
+
+  final Completer<void> started;
+  final Completer<void> release;
+}
 
 void main() {
   group('emitEffect', () {
@@ -30,6 +48,44 @@ void main() {
         );
       });
       expect(didThrow, isTrue);
+    });
+
+    test('drains an in-flight effect before closing', () async {
+      final started = Completer<void>();
+      final release = Completer<void>();
+      final bloc = DelayedBloc(started: started, release: release);
+      final effects = <TestEffect>[];
+      final subscription = bloc.effectsStream.listen(effects.add);
+
+      bloc.add(const DelayedEvent());
+      await started.future;
+      final closeFuture = bloc.close();
+      release.complete();
+      await closeFuture;
+
+      expect(effects, hasLength(1));
+      expect(effects.single, isA<ShowSnackBar>());
+      await subscription.cancel();
+    });
+
+    test('concurrent close calls wait for the same paused stream', () async {
+      final cubit = TestCubit();
+      final subscription = cubit.effectsStream.listen((_) {})..pause();
+
+      final firstClose = cubit.close();
+      final secondClose = cubit.close();
+      var completed = false;
+      unawaited(firstClose.then((_) => completed = true));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(identical(firstClose, secondClose), isTrue);
+      expect(cubit.isClosed, isTrue);
+      expect(completed, isFalse);
+
+      subscription.resume();
+      await firstClose;
+      await secondClose;
+      await subscription.cancel();
     });
   });
 }

--- a/test/bloc_with_effects_observer_test.dart
+++ b/test/bloc_with_effects_observer_test.dart
@@ -1,4 +1,4 @@
-import 'package:bloc_effects/src/bloc_with_effects_observer.dart';
+import 'package:bloc_effects/bloc_effects.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -10,10 +10,22 @@ class TestBlocObserver extends BlocWithEffectsObserver {
   final Map<BlocBase<dynamic>, List<dynamic>> observedEffects;
 
   @override
-  void onEffect<E>(BlocBase<dynamic> bloc, E effect) {
+  void onBlocEffect(BlocBase<dynamic> bloc, Object? effect) {
     observedEffects.putIfAbsent(bloc, () => []);
     observedEffects[bloc]!.add(effect);
-    super.onEffect(bloc, effect);
+    super.onBlocEffect(bloc, effect);
+  }
+}
+
+class LegacyBlocObserver extends BlocWithEffectsObserver {
+  LegacyBlocObserver(this.observedEffects);
+
+  final List<Object?> observedEffects;
+
+  @override
+  void onEffect<E>(E effect) {
+    observedEffects.add(effect);
+    super.onEffect<E>(effect);
   }
 }
 
@@ -21,10 +33,13 @@ void main() {
   group('BlocWithEffectsObserver', () {
     group('onEffect', () {
       test('Emitted effects are observed correctly', () async {
-        final bloc = TestBloc();
+        final originalObserver = Bloc.observer;
         final observedEffects = <BlocBase<dynamic>, List<dynamic>>{};
         final testBlocObserver = TestBlocObserver(observedEffects);
         Bloc.observer = testBlocObserver;
+        addTearDown(() => Bloc.observer = originalObserver);
+        final bloc = TestBloc();
+        addTearDown(bloc.close);
 
         expect(
           observedEffects,
@@ -44,6 +59,19 @@ void main() {
           },
           reason: 'ButtonPressed event, should trigger a ShowSnackBar effect',
         );
+      });
+
+      test('legacy onEffect overrides continue to receive effects', () {
+        final originalObserver = Bloc.observer;
+        final observedEffects = <Object?>[];
+        Bloc.observer = LegacyBlocObserver(observedEffects);
+        addTearDown(() => Bloc.observer = originalObserver);
+        final cubit = TestCubit();
+        addTearDown(cubit.close);
+
+        cubit.showSnackBar();
+
+        expect(observedEffects, <Object?>[isA<ShowSnackBar>()]);
       });
     });
   });

--- a/test/bloc_with_effects_observer_test.dart
+++ b/test/bloc_with_effects_observer_test.dart
@@ -1,16 +1,49 @@
 import 'package:bloc_effects/src/bloc_with_effects_observer.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'bloc_effect_listener_test.dart';
 
-class TestBlocObserver extends BlocWithEffectsObserver {}
+class TestBlocObserver extends BlocWithEffectsObserver {
+  TestBlocObserver(this.observedEffects);
+
+  final Map<BlocBase<dynamic>, List<dynamic>> observedEffects;
+
+  @override
+  void onEffect<E>(BlocBase<dynamic> bloc, E effect) {
+    observedEffects.putIfAbsent(bloc, () => []);
+    observedEffects[bloc]!.add(effect);
+    super.onEffect(bloc, effect);
+  }
+}
 
 void main() {
   group('BlocWithEffectsObserver', () {
     group('onEffect', () {
-      test('does nothing by default', () {
-        // ignore: invalid_use_of_protected_member
-        TestBlocObserver().onEffect(const ShowSnackBar(1));
+      test('Emitted effects are observed correctly', () async {
+        final bloc = TestBloc();
+        final observedEffects = <BlocBase<dynamic>, List<dynamic>>{};
+        final testBlocObserver = TestBlocObserver(observedEffects);
+        Bloc.observer = testBlocObserver;
+
+        expect(
+          observedEffects,
+          isEmpty,
+          reason: 'No observed effects on creation',
+        );
+
+        bloc.add(const ButtonPressed());
+
+        // Important: wait for a delay to trigger effect emission
+        await Future<void>.delayed(Duration.zero);
+
+        expect(
+          observedEffects,
+          {
+            bloc: [isA<ShowSnackBar>()],
+          },
+          reason: 'ButtonPressed event, should trigger a ShowSnackBar effect',
+        );
       });
     });
   });


### PR DESCRIPTION
Hello @DartAndrik,

as I said in issue #22, I implemented the change myself.

I understand it's a breaking change, but it's a step towards standardization of method signatures to be more consistent with `bloc` ones.

What I changed:
- added `bloc` parameter in `BlocEffectObserver.onEffect`
    - added generics in all related classes
- changed `mixin Effects on BlocBase<State>` (instead of `on Closable`)
- added `BlocEffectConsumer` convenience stateless widget (which combines a `BlocBuilder` and a `BlocEffectListener`)

I hope everything is alright and you find this change useful, even if it's breaking.